### PR TITLE
Fix NullRef when Target doesn't have an Orbit component

### DIFF
--- a/MicroEngineerProject/MicroEngineer/MicroEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEntries.cs
@@ -832,7 +832,7 @@ namespace MicroMod
 
         public override void RefreshData()
         {
-            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit.ApoapsisArl;
+            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit?.ApoapsisArl;
         }
 
         public override string ValueDisplay
@@ -860,7 +860,7 @@ namespace MicroMod
 
         public override void RefreshData()
         {
-            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit.PeriapsisArl;
+            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit?.PeriapsisArl;
         }
 
         public override string ValueDisplay
@@ -888,7 +888,7 @@ namespace MicroMod
 
         public override void RefreshData()
         {
-            EntryValue = MicroUtility.ActiveVessel.TargetObject != null ? (MicroUtility.ActiveVessel.Orbit.Position - MicroUtility.ActiveVessel.TargetObject.Orbit.Position).magnitude : null;
+            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit != null ? (MicroUtility.ActiveVessel.Orbit.Position - MicroUtility.ActiveVessel.TargetObject.Orbit.Position).magnitude : null;
         }
 
         public override string ValueDisplay
@@ -918,7 +918,7 @@ namespace MicroMod
 
         public override void RefreshData()
         {
-            EntryValue = MicroUtility.ActiveVessel.TargetObject != null ? (MicroUtility.ActiveVessel.Orbit.relativeVelocity - MicroUtility.ActiveVessel.TargetObject.Orbit.relativeVelocity).magnitude : null;
+            EntryValue = MicroUtility.ActiveVessel.TargetObject?.Orbit != null ? (MicroUtility.ActiveVessel.Orbit.relativeVelocity - MicroUtility.ActiveVessel.TargetObject.Orbit.relativeVelocity).magnitude : null;
         }
 
         public override string ValueDisplay
@@ -961,7 +961,7 @@ namespace MicroMod
                     return "-";
 
                 // return value only if vessel and target are in the same SOI
-                if (MicroUtility.ActiveVessel.Orbit.referenceBody != MicroUtility.ActiveVessel.TargetObject?.Orbit.referenceBody)
+                if (MicroUtility.ActiveVessel.Orbit.referenceBody != MicroUtility.ActiveVessel.TargetObject?.Orbit?.referenceBody)
                     return "-";
 
                 return String.IsNullOrEmpty(base.Formatting) ? EntryValue.ToString() : String.Format(base.Formatting, EntryValue);


### PR DESCRIPTION
If you target a docking port then the TargetObject.Orbit will be null. This prevents exceptions being generated.