### PR TITLE
Snap windows and rename entries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Micrologist
+Copyright (c) 2023 Micrologist, Falki-git
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MicroEngineerProject/MicroEngineer/Entries/BaseEntry.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/BaseEntry.cs
@@ -11,6 +11,7 @@ namespace MicroMod
         [JsonProperty]
         public string Name;
         [JsonProperty]
+        public Guid Id;
         public string Description;
         [JsonProperty]
         public MicroEntryCategory Category;

--- a/MicroEngineerProject/MicroEngineer/Managers/Manager.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/Manager.cs
@@ -7,22 +7,30 @@ namespace MicroMod
 {
     internal class Manager
     {
+        private static Manager _instance;
+
         internal List<BaseWindow> Windows;
         internal List<BaseEntry> Entries;
-        internal UI UI;
-        internal MessageManager MessageManager;
-        private MicroEngineerMod _plugin;        
 
         private static readonly ManualLogSource _logger = BepInEx.Logging.Logger.CreateLogSource("MicroEngineer.Manager");
 
-        internal Manager(MicroEngineerMod plugin)
+        public List<string> TextFieldNames = new List<string>();
+
+        internal Manager()
         {
-            _plugin = plugin;
             Entries = InitializeEntries();
             Windows = InitializeWindows();
+        }
 
-            // Load window positions and states from disk, if file exists
-            Utility.LoadLayout(Windows);
+        public static Manager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new Manager();
+
+                return _instance;
+            }
         }
 
         public void Update()
@@ -297,17 +305,28 @@ namespace MicroMod
             Entries.Clear();
             Entries = InitializeEntries();
             Windows = InitializeWindows();
-            UI.Windows = Windows;
-            MessageManager.Windows = Windows; 
         }
 
         internal void LoadLayout()
         {
             Utility.LoadLayout(Windows);
-            UI.Windows = Windows;
-            MessageManager.Windows = Windows;
         }
 
         internal void SaveLayout() => Utility.SaveLayout(Windows);
+
+        public void PupulateTextFieldNames(List<BaseEntry> entries)
+        {
+            TextFieldNames.Clear();
+            TextFieldNames.Add(Utility.InputDisableWindowAbbreviation);
+            TextFieldNames.Add(Utility.InputDisableWindowName);
+
+            foreach (var entry in entries)
+            {
+                entry.Id = Guid.NewGuid();
+                TextFieldNames.Add(entry.Id.ToString());
+            }
+        }
+
+        public void AddTextFieldName(string name) => TextFieldNames.Add(name);
     }
 }

--- a/MicroEngineerProject/MicroEngineer/Managers/MessageManager.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/MessageManager.cs
@@ -7,25 +7,26 @@ namespace MicroMod
 {
     internal class MessageManager
     {
-        MicroEngineerMod _plugin;
-        private Manager _manager;
-        private UI _ui;
-        internal List<BaseWindow> Windows;
+        private static MessageManager _instance;
 
-        internal MessageManager(MicroEngineerMod plugin, Manager manager, UI ui)
+        internal MessageManager()
+        { }
+
+        public static MessageManager Instance
         {
-            _plugin = plugin;
-            _manager = manager;
-            _ui = ui;
-            Windows = _manager.Windows;
+            get
+            {
+                if (_instance == null)
+                    _instance = new MessageManager();
 
-            SubscribeToMessages();
+                return _instance;
+            }
         }
 
         /// <summary>
         /// Subscribe to KSP2 messages
         /// </summary>
-        internal void SubscribeToMessages()
+        public void SubscribeToMessages()
         {
             Utility.RefreshGameManager();
 
@@ -50,21 +51,21 @@ namespace MicroMod
 
         private void OnManeuverCreatedMessage(MessageCenterMessage message)
         {
-            var maneuverWindow = Windows.Find(w => w.GetType() == typeof(ManeuverWindow)) as ManeuverWindow;
+            var maneuverWindow = Manager.Instance.Windows.Find(w => w.GetType() == typeof(ManeuverWindow)) as ManeuverWindow;
             maneuverWindow.OnManeuverCreatedMessage(message);
         }
 
         private void OnManeuverRemovedMessage(MessageCenterMessage message)
         {
-            var maneuverWindow = Windows.Find(w => w.GetType() == typeof(ManeuverWindow)) as ManeuverWindow;
+            var maneuverWindow = Manager.Instance.Windows.Find(w => w.GetType() == typeof(ManeuverWindow)) as ManeuverWindow;
             maneuverWindow.OnManeuverRemovedMessage(message);
         }
 
         private void OnPartManipulationCompletedMessage(MessageCenterMessage obj)
         {
-            EntryWindow stageInfoOabWindow = Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB);
+            EntryWindow stageInfoOabWindow = Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB);
 
-            Torque torque = (Torque)Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).Entries.Find(e => e.Name == "Torque");
+            Torque torque = (Torque)Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).Entries.Find(e => e.Name == "Torque");
             torque.RefreshData();
         }
 
@@ -73,22 +74,20 @@ namespace MicroMod
             Utility.RefreshGameManager();
             if (Utility.GameState.GameState == GameState.FlightView || Utility.GameState.GameState == GameState.VehicleAssemblyBuilder || Utility.GameState.GameState == GameState.Map3DView)
             {
-                Utility.LoadLayout(Windows);
-                _manager.Windows = Windows;
-                _ui.Windows = Windows;
+                Utility.LoadLayout(Manager.Instance.Windows);
 
                 if (Utility.GameState.GameState == GameState.FlightView || Utility.GameState.GameState == GameState.Map3DView)
                 {
-                    _ui.ShowGuiFlight = Windows.OfType<MainGuiWindow>().FirstOrDefault().IsFlightActive;
-                    GameObject.Find("BTN-MicroEngineerBtn")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(_ui.ShowGuiFlight);
+                    UI.Instance.ShowGuiFlight = Manager.Instance.Windows.OfType<MainGuiWindow>().FirstOrDefault().IsFlightActive;
+                    GameObject.Find("BTN-MicroEngineerBtn")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(UI.Instance.ShowGuiFlight);
                 }    
 
                 if (Utility.GameState.GameState == GameState.VehicleAssemblyBuilder)
                 {
-                    _ui.ShowGuiOAB = Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).IsEditorActive;
-                    GameObject.Find("BTN - MicroEngineerOAB")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(_ui.ShowGuiOAB);
-                    _ui.CelestialBodies.GetBodies();
-                    _ui.CelestialBodySelectionStageIndex = -1;
+                    UI.Instance.ShowGuiOAB = Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).IsEditorActive;
+                    GameObject.Find("BTN - MicroEngineerOAB")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(UI.Instance.ShowGuiOAB);
+                    UI.Instance.CelestialBodies.GetBodies();
+                    UI.Instance.CelestialBodySelectionStageIndex = -1;
                     Styles.SetActiveTheme(Theme.Gray); // TODO implement other themes in OAB
                 }
             }
@@ -99,13 +98,13 @@ namespace MicroMod
             Utility.RefreshGameManager();
             if (Utility.GameState.GameState == GameState.FlightView || Utility.GameState.GameState == GameState.VehicleAssemblyBuilder || Utility.GameState.GameState == GameState.Map3DView)
             {
-                Utility.SaveLayout(Windows);
+                Utility.SaveLayout(Manager.Instance.Windows);
 
                 if (Utility.GameState.GameState == GameState.FlightView || Utility.GameState.GameState == GameState.Map3DView)
-                    _ui.ShowGuiFlight = false;
+                    UI.Instance.ShowGuiFlight = false;
 
                 if (Utility.GameState.GameState == GameState.VehicleAssemblyBuilder)
-                    _ui.ShowGuiOAB = false;
+                    UI.Instance.ShowGuiOAB = false;
             }
         }
 
@@ -123,7 +122,7 @@ namespace MicroMod
 
             Utility.RefreshStagesOAB();
 
-            EntryWindow stageWindow = Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB);
+            EntryWindow stageWindow = Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB);
 
             if (Utility.VesselDeltaVComponentOAB?.StageInfo == null)
             {

--- a/MicroEngineerProject/MicroEngineer/Managers/UI.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/UI.cs
@@ -176,8 +176,7 @@ namespace MicroMod
             {
                 Manager.Instance.SaveLayout();
                 _showGuiSettingsFlight = false;
-            }                
-            GUILayout.Space(5);
+            }
             if (GUILayout.Button("LOAD LAYOUT", Styles.NormalBtnStyle))
                 Manager.Instance.LoadLayout();
             if (GUILayout.Button("RESET LAYOUT", Styles.NormalBtnStyle))
@@ -210,6 +209,11 @@ namespace MicroMod
                 settingsWindow.ActiveTheme = Theme.Black;
             }
             GUILayout.EndHorizontal();
+
+            GUILayout.Space(10);
+            GUILayout.Label("<b>Other</b>");
+            GUILayout.Space(-10);
+            settingsWindow.SnapWindows = GUILayout.Toggle(settingsWindow.SnapWindows, "Window snapping", Styles.SectionToggleStyle);
 
             GUI.DragWindow(new Rect(0, 0, Screen.width, Screen.height));
         }

--- a/MicroEngineerProject/MicroEngineer/Managers/UI.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/UI.cs
@@ -766,32 +766,40 @@ namespace MicroMod
 
             foreach (var otherWindow in poppedOutWindows)
             {
-                if (otherWindow != draggedWindow)
+                // Check if the current window is close to any edge of the other window
+                if (otherWindow != draggedWindow && Utility.AreRectsNear(draggedWindow.FlightRect, otherWindow.FlightRect))
                 {
-                    // Check if the current window is close to any edge of the other window
+                    // Snap to the left edge
                     if (Mathf.Abs(draggedWindow.FlightRect.xMin - otherWindow.FlightRect.xMin) < settings.SnapDistance)
-                        draggedWindow.FlightRect.x = otherWindow.FlightRect.xMin; // Snap to the left edge
+                        draggedWindow.FlightRect.x = otherWindow.FlightRect.xMin;
 
+                    // Snap to the right edge
                     if (Mathf.Abs(draggedWindow.FlightRect.xMax - otherWindow.FlightRect.xMin) < settings.SnapDistance)
-                        draggedWindow.FlightRect.x = otherWindow.FlightRect.xMin - draggedWindow.FlightRect.width; // Snap to the right edge
+                            draggedWindow.FlightRect.x = otherWindow.FlightRect.xMin - draggedWindow.FlightRect.width;
 
+                    // Snap to the left edge
                     if (Mathf.Abs(draggedWindow.FlightRect.xMin - otherWindow.FlightRect.xMax) < settings.SnapDistance)
-                        draggedWindow.FlightRect.x = otherWindow.FlightRect.xMax; // Snap to the left edge
+                            draggedWindow.FlightRect.x = otherWindow.FlightRect.xMax;
 
+                    // Snap to the right edge
                     if (Mathf.Abs(draggedWindow.FlightRect.xMax - otherWindow.FlightRect.xMax) < settings.SnapDistance)
-                        draggedWindow.FlightRect.x = otherWindow.FlightRect.xMax - draggedWindow.FlightRect.width; // Snap to the right edge
+                            draggedWindow.FlightRect.x = otherWindow.FlightRect.xMax - draggedWindow.FlightRect.width;
 
+                    // Snap to the top edge
                     if (Mathf.Abs(draggedWindow.FlightRect.yMin - otherWindow.FlightRect.yMin) < settings.SnapDistance)
-                        draggedWindow.FlightRect.y = otherWindow.FlightRect.yMin; // Snap to the top edge
+                            draggedWindow.FlightRect.y = otherWindow.FlightRect.yMin;
 
+                    // Snap to the bottom edge
                     if (Mathf.Abs(draggedWindow.FlightRect.yMax - otherWindow.FlightRect.yMin) < settings.SnapDistance)
-                        draggedWindow.FlightRect.y = otherWindow.FlightRect.yMin - draggedWindow.FlightRect.height; // Snap to the bottom edge
+                            draggedWindow.FlightRect.y = otherWindow.FlightRect.yMin - draggedWindow.FlightRect.height;
 
+                    // Snap to the top edge
                     if (Mathf.Abs(draggedWindow.FlightRect.yMin - otherWindow.FlightRect.yMax) < settings.SnapDistance)
-                        draggedWindow.FlightRect.y = otherWindow.FlightRect.yMax; // Snap to the top edge
+                            draggedWindow.FlightRect.y = otherWindow.FlightRect.yMax;
 
+                    // Snap to the bottom edge
                     if (Mathf.Abs(draggedWindow.FlightRect.yMax - otherWindow.FlightRect.yMax) < settings.SnapDistance)
-                        draggedWindow.FlightRect.y = otherWindow.FlightRect.yMax - draggedWindow.FlightRect.height; // Snap to the bottom edge
+                            draggedWindow.FlightRect.y = otherWindow.FlightRect.yMax - draggedWindow.FlightRect.height;
                 }
             }
         }

--- a/MicroEngineerProject/MicroEngineer/Managers/UI.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/UI.cs
@@ -488,8 +488,9 @@ namespace MicroMod
                 GUIStyle backgroundStyle = i == 0 ? Styles.EntryBackground_First : i < entries.Count - 1 ? Styles.EntryBackground_Middle : Styles.EntryBackground_Last;
 
                 GUILayout.BeginHorizontal(backgroundStyle);
-                
-                GUILayout.Label(entries[i].Name, Styles.NameLabelStyle);
+
+                entries[i].Name = GUILayout.TextField(entries[i].Name, Styles.InstalledEntryFieldStyle);
+                GUILayout.FlexibleSpace();
                 GUI.enabled = entries[i].NumberOfDecimalDigits < 5;
                 if (entries[i].Formatting != null && GUILayout.Button(Styles.IncreaseDecimalDigitsTexture, Styles.OneCharacterBtnStyle))
                 {

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -8,15 +8,18 @@ using KSP.UI.Binding;
 
 namespace MicroMod
 {
-    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.0.3")]
-	[BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
-	public class MicroEngineerMod : BaseSpaceWarpPlugin
+    //[BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
+    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.1.0")]    
+    [BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
+    public class MicroEngineerMod : BaseSpaceWarpPlugin
 	{
         public static MicroEngineerMod Instance { get; set; }
+        public string GUID;
 
         public override void OnInitialized()
 		{
             Instance = this;
+            GUID = Info.Metadata.GUID;
 
             Styles.Initialize();
 
@@ -28,7 +31,7 @@ namespace MicroMod
             Appbar.RegisterAppButton(
                 "Micro Engineer",
                 "BTN-MicroEngineerBtn",
-                AssetManager.GetAsset<Texture2D>($"{SpaceWarpMetadata.ModID}/images/icon.png"),
+                AssetManager.GetAsset<Texture2D>($"{GUID}/images/icon.png"),
                 isOpen =>
                 {
                     UI.Instance.ShowGuiFlight = isOpen;
@@ -39,7 +42,7 @@ namespace MicroMod
             Appbar.RegisterOABAppButton(
                 "Micro Engineer",
                 "BTN-MicroEngineerOAB",
-                AssetManager.GetAsset<Texture2D>($"{SpaceWarpMetadata.ModID}/images/icon.png"),
+                AssetManager.GetAsset<Texture2D>($"{GUID}/images/icon.png"),
                 isOpen =>
                 {
                     UI.Instance.ShowGuiOAB = isOpen;

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -19,13 +19,14 @@ namespace MicroMod
         public override void OnInitialized()
 		{
             Instance = this;
+            
             GUID = Info.Metadata.GUID;
+            
+            BackwardCompatibilityInitializations();
 
             Styles.Initialize();
 
             MessageManager.Instance.SubscribeToMessages();
-
-            BackwardCompatibilityInitializations();
 
             // Register Flight and OAB buttons
             Appbar.RegisterAppButton(
@@ -47,22 +48,22 @@ namespace MicroMod
                 {
                     UI.Instance.ShowGuiOAB = isOpen;
                     Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).IsEditorActive = isOpen;
-                    GameObject.Find("BTN - MicroEngineerOAB")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(isOpen);
+                    GameObject.Find("BTN-MicroEngineerOAB")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(isOpen);
                 });
         }
 
         private void BackwardCompatibilityInitializations()
         {
-            // Preserve backward compatibility with SpaceWarp 1.0.1
-            if (Utility.IsModOlderThan("SpaceWarp", 1, 1, 0))
+            // Preserve backward compatibility with SpaceWarp 1.1.x
+            if (Utility.IsModOlderThan("SpaceWarp", 1, 2, 0))
             {
-                Logger.LogInfo("Space Warp older version detected. Loading old Styles.");
-                Styles.SetStylesForOldSpaceWarpSkin();
+                Logger.LogInfo("Older Space Warp version detected. Setting mod GUID to \"micro_engineer\".");
+                GUID = "micro_engineer";
             }
             else
-                Logger.LogInfo("Space Warp new version detected. Loading new Styles.");
+                Logger.LogInfo("New Space Warp version detected. No backward compatibility needed.");
         }
-        
+
         public void Update()
         {
             Manager.Instance.Update();

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -12,21 +12,17 @@ namespace MicroMod
 	[BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
 	public class MicroEngineerMod : BaseSpaceWarpPlugin
 	{
-        private Manager _manager;
-        private MessageManager _messagesManager;
-        private UI _ui;
+        public static MicroEngineerMod Instance { get; set; }
 
         public override void OnInitialized()
 		{
-            Styles.Initialize(this);
+            Instance = this;
 
-            _manager = new Manager(this);
-            _ui = new UI(this, _manager);            
-            _messagesManager = new MessageManager(this, _manager, _ui);
-            _manager.UI = _ui;
-            _manager.MessageManager = _messagesManager;
+            Styles.Initialize();
 
-            BackwardCompatibilityInitializations();            
+            MessageManager.Instance.SubscribeToMessages();
+
+            BackwardCompatibilityInitializations();
 
             // Register Flight and OAB buttons
             Appbar.RegisterAppButton(
@@ -35,8 +31,8 @@ namespace MicroMod
                 AssetManager.GetAsset<Texture2D>($"{SpaceWarpMetadata.ModID}/images/icon.png"),
                 isOpen =>
                 {
-                    _ui.ShowGuiFlight = isOpen;
-                    _manager.Windows.Find(w => w.GetType() == typeof(MainGuiWindow)).IsFlightActive = isOpen;
+                    UI.Instance.ShowGuiFlight = isOpen;
+                    Manager.Instance.Windows.Find(w => w.GetType() == typeof(MainGuiWindow)).IsFlightActive = isOpen;
                     GameObject.Find("BTN-MicroEngineerBtn")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(isOpen);
                 });
 
@@ -46,8 +42,8 @@ namespace MicroMod
                 AssetManager.GetAsset<Texture2D>($"{SpaceWarpMetadata.ModID}/images/icon.png"),
                 isOpen =>
                 {
-                    _ui.ShowGuiOAB = isOpen;
-                    _manager.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).IsEditorActive = isOpen;
+                    UI.Instance.ShowGuiOAB = isOpen;
+                    Manager.Instance.Windows.FindAll(w => w is EntryWindow).Cast<EntryWindow>().ToList().Find(w => w.MainWindow == MainWindow.StageInfoOAB).IsEditorActive = isOpen;
                     GameObject.Find("BTN - MicroEngineerOAB")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(isOpen);
                 });
         }
@@ -66,12 +62,12 @@ namespace MicroMod
         
         public void Update()
         {
-            _manager?.Update();
+            Manager.Instance.Update();
         }
 
         private void OnGUI()
         {
-            _ui?.OnGUI();
+            UI.Instance.OnGUI();
         }
     }
 }

--- a/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
@@ -10,8 +10,6 @@ namespace MicroMod
 
     public static class Styles
     {
-        private static MicroEngineerMod _plugin;
-
         private static readonly ManualLogSource _logger = BepInEx.Logging.Logger.CreateLogSource("MicroEngineer.Styles");
 
         public static int WindowWidth = 290;
@@ -125,10 +123,8 @@ namespace MicroMod
 
         public static Theme ActiveTheme;
 
-        public static void Initialize(MicroEngineerMod plugin)
+        public static void Initialize()
         {
-            _plugin = plugin;
-
             InitializeTextures();
             InitializeStyles();
             SetActiveTheme(Theme.Gray);
@@ -371,25 +367,25 @@ namespace MicroMod
         {
             // Icons from https://icons8.com
 
-            Settings20Texture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/settings-20.png");
-            Settings15Texture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/settings-15.png");
-            CloseButtonTexture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/close-15.png");
-            PopoutTexture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/popout-15.png");            
+            Settings20Texture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/settings-20.png");
+            Settings15Texture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/settings-15.png");
+            CloseButtonTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/close-15.png");
+            PopoutTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/popout-15.png");            
 
-            EntryBackgroundTexture_WhiteTheme_First = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_white_first.png");
-            EntryBackgroundTexture_WhiteTheme_Middle = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_white_middle.png");
-            EntryBackgroundTexture_WhiteTheme_Last = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_white_last.png");
+            EntryBackgroundTexture_WhiteTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_first.png");
+            EntryBackgroundTexture_WhiteTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_middle.png");
+            EntryBackgroundTexture_WhiteTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_last.png");
 
-            EntryBackgroundTexture_GrayTheme_First = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_darkgray_first.png");
-            EntryBackgroundTexture_GrayTheme_Middle = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_darkgray_middle.png");
-            EntryBackgroundTexture_GrayTheme_Last = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_darkgray_last.png");
+            EntryBackgroundTexture_GrayTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_first.png");
+            EntryBackgroundTexture_GrayTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_middle.png");
+            EntryBackgroundTexture_GrayTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_last.png");
 
-            EntryBackgroundTexture_BlackTheme_First = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_black_first.png");
-            EntryBackgroundTexture_BlackTheme_Middle = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_black_middle.png");
-            EntryBackgroundTexture_BlackTheme_Last = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/background_black_last.png");
+            EntryBackgroundTexture_BlackTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_first.png");
+            EntryBackgroundTexture_BlackTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_middle.png");
+            EntryBackgroundTexture_BlackTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_last.png");
 
-            IncreaseDecimalDigitsTexture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/increase-decimal-19.png");
-            DecreaseDecimalDigitsTexture = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/decrease-decimal-19.png");            
+            IncreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/increase-decimal-19.png");
+            DecreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/decrease-decimal-19.png");            
         }
 
         private static Texture2D LoadTexture(string path)

--- a/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
@@ -44,6 +44,7 @@ namespace MicroMod
 
         public static GUIStyle WindowSelectionTextFieldStyle;
         public static GUIStyle WindowSelectionAbbrevitionTextFieldStyle;
+        public static GUIStyle InstalledEntryFieldStyle;
 
         public static GUIStyle CloseMainGuiBtnStyle;
         public static GUIStyle CloseBtnStyle;
@@ -245,6 +246,8 @@ namespace MicroMod
             };
             BlueLabelStyle.normal.textColor = _valueColor;
 
+            ///// TEXTFIELDS /////
+
             WindowSelectionTextFieldStyle = new GUIStyle(SpaceWarpUISkin.textField)
             {
                 alignment = TextAnchor.MiddleCenter,
@@ -255,6 +258,12 @@ namespace MicroMod
             {
                 alignment = TextAnchor.MiddleCenter,
                 fixedWidth = 40
+            };
+
+            InstalledEntryFieldStyle = new GUIStyle(SpaceWarpUISkin.textField)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fixedWidth = 120
             };
 
             ///// BUTTONS /////

--- a/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Styles.cs
@@ -367,25 +367,25 @@ namespace MicroMod
         {
             // Icons from https://icons8.com
 
-            Settings20Texture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/settings-20.png");
-            Settings15Texture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/settings-15.png");
-            CloseButtonTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/close-15.png");
-            PopoutTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/popout-15.png");            
+            Settings20Texture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/settings-20.png");
+            Settings15Texture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/settings-15.png");
+            CloseButtonTexture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/close-15.png");
+            PopoutTexture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/popout-15.png");            
 
-            EntryBackgroundTexture_WhiteTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_first.png");
-            EntryBackgroundTexture_WhiteTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_middle.png");
-            EntryBackgroundTexture_WhiteTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_white_last.png");
+            EntryBackgroundTexture_WhiteTheme_First = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_white_first.png");
+            EntryBackgroundTexture_WhiteTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_white_middle.png");
+            EntryBackgroundTexture_WhiteTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_white_last.png");
 
-            EntryBackgroundTexture_GrayTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_first.png");
-            EntryBackgroundTexture_GrayTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_middle.png");
-            EntryBackgroundTexture_GrayTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_darkgray_last.png");
+            EntryBackgroundTexture_GrayTheme_First = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_darkgray_first.png");
+            EntryBackgroundTexture_GrayTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_darkgray_middle.png");
+            EntryBackgroundTexture_GrayTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_darkgray_last.png");
 
-            EntryBackgroundTexture_BlackTheme_First = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_first.png");
-            EntryBackgroundTexture_BlackTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_middle.png");
-            EntryBackgroundTexture_BlackTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/background_black_last.png");
+            EntryBackgroundTexture_BlackTheme_First = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_black_first.png");
+            EntryBackgroundTexture_BlackTheme_Middle = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_black_middle.png");
+            EntryBackgroundTexture_BlackTheme_Last = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/background_black_last.png");
 
-            IncreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/increase-decimal-19.png");
-            DecreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.SpaceWarpMetadata.ModID}/images/decrease-decimal-19.png");            
+            IncreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/increase-decimal-19.png");
+            DecreaseDecimalDigitsTexture = LoadTexture($"{MicroEngineerMod.Instance.GUID}/images/decrease-decimal-19.png");            
         }
 
         private static Texture2D LoadTexture(string path)

--- a/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
@@ -248,7 +248,7 @@ namespace MicroMod
         {
             if (gameInputState)
             {
-                if (InputDisableWindowAbbreviation == GUI.GetNameOfFocusedControl() || InputDisableWindowName == GUI.GetNameOfFocusedControl())
+                if (Manager.Instance.TextFieldNames.Contains(GUI.GetNameOfFocusedControl()))
                 {
                     GameManager.Instance.Game.Input.Disable();
                     return false;
@@ -258,7 +258,7 @@ namespace MicroMod
             }
             else
             {
-                if (InputDisableWindowAbbreviation != GUI.GetNameOfFocusedControl() && InputDisableWindowName != GUI.GetNameOfFocusedControl() || !showGuiFlight)
+                if (!Manager.Instance.TextFieldNames.Contains(GUI.GetNameOfFocusedControl()) || !showGuiFlight)
                 {
                     GameManager.Instance.Game.Input.Enable();
                     return true;
@@ -330,7 +330,7 @@ namespace MicroMod
         {
             float distanceX = Mathf.Abs(rect1.center.x - rect2.center.x);
             float distanceY = Mathf.Abs(rect1.center.y - rect2.center.y);            
-            return (distanceX < rect1.width / 2 + rect2.width / 2 + 100f && distanceY < rect1.height / 2 + rect2.height / 2 + 100f);
+            return (distanceX < rect1.width / 2 + rect2.width / 2 + 50f && distanceY < rect1.height / 2 + rect2.height / 2 + 50f);
         }
     }    
 }

--- a/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
@@ -288,7 +288,7 @@ namespace MicroMod
                 if (versionNumbers.Length == 3)
                     int.TryParse(versionNumbers[2], out patchVersion);
 
-                Logger.LogInfo($"Space Warp version {majorVersion}.{minorVersion}.{patchVersion} detected.");
+                Logger.LogInfo($"{modId} version {majorVersion}.{minorVersion}.{patchVersion} detected.");
 
                 return (majorVersion, minorVersion, patchVersion);
             }

--- a/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
@@ -325,5 +325,12 @@ namespace MicroMod
             else
                 return false;
         }
+
+        public static bool AreRectsNear(Rect rect1, Rect rect2)
+        {
+            float distanceX = Mathf.Abs(rect1.center.x - rect2.center.x);
+            float distanceY = Mathf.Abs(rect1.center.y - rect2.center.y);            
+            return (distanceX < rect1.width / 2 + rect2.width / 2 + 100f && distanceY < rect1.height / 2 + rect2.height / 2 + 100f);
+        }
     }    
 }

--- a/MicroEngineerProject/MicroEngineer/Windows/EntryWindow.cs
+++ b/MicroEngineerProject/MicroEngineer/Windows/EntryWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using UnityEngine;
 
 namespace MicroMod
 {
@@ -35,6 +36,8 @@ namespace MicroMod
         /// </summary>
         [JsonProperty]
         internal bool IsEditable { get => MainWindow != MainWindow.Stage && MainWindow != MainWindow.StageInfoOAB; }
+
+        internal bool IsBeingDragged { get => FlightRect.Contains(Event.current.mousePosition); }
 
         [JsonProperty]
         internal MainWindow MainWindow;

--- a/MicroEngineerProject/MicroEngineer/Windows/SettingsWIndow.cs
+++ b/MicroEngineerProject/MicroEngineer/Windows/SettingsWIndow.cs
@@ -7,6 +7,12 @@ namespace MicroMod
     {
         [JsonProperty]
         internal Theme ActiveTheme { get; set; }
+        [JsonProperty]
+        private bool snapWindows = true;
+        internal bool SnapWindows { get => snapWindows; set => snapWindows = value; }
+        [JsonProperty]
+        private float snapDistance = 10f;
+        internal float SnapDistance { get => snapDistance; set => snapDistance = value; }
 
         internal void LoadSettings()
         {

--- a/MicroEngineerProject/MicroEngineer/Windows/SettingsWIndow.cs
+++ b/MicroEngineerProject/MicroEngineer/Windows/SettingsWIndow.cs
@@ -11,7 +11,7 @@ namespace MicroMod
         private bool snapWindows = true;
         internal bool SnapWindows { get => snapWindows; set => snapWindows = value; }
         [JsonProperty]
-        private float snapDistance = 10f;
+        private float snapDistance = 20f;
         internal float SnapDistance { get => snapDistance; set => snapDistance = value; }
 
         internal void LoadSettings()

--- a/MicroEngineerProject/MicroEngineer/Windows/StageWindow.cs
+++ b/MicroEngineerProject/MicroEngineer/Windows/StageWindow.cs
@@ -23,7 +23,7 @@ namespace MicroMod
                     GUILayout.Height(0)
                     );
 
-                var settings = ui.Windows.Find(w => w is SettingsWIndow) as SettingsWIndow;
+                var settings = Manager.Instance.Windows.Find(w => w is SettingsWIndow) as SettingsWIndow;
                 if (settings.SnapWindows && this.IsBeingDragged)
                     ui.HandleSnapping(this);
 

--- a/MicroEngineerProject/MicroEngineer/Windows/StageWindow.cs
+++ b/MicroEngineerProject/MicroEngineer/Windows/StageWindow.cs
@@ -23,6 +23,10 @@ namespace MicroMod
                     GUILayout.Height(0)
                     );
 
+                var settings = ui.Windows.Find(w => w is SettingsWIndow) as SettingsWIndow;
+                if (settings.SnapWindows && this.IsBeingDragged)
+                    ui.HandleSnapping(this);
+
                 this.FlightRect.position = Utility.ClampToScreen(this.FlightRect.position, this.FlightRect.size);
             }
             else

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micro Engineer - a KSP2 plugin
 Displays useful in-flight information about your vessel, your orbital and surface parameters and many other things.
-![Micro Engineer](https://i.imgur.com/I7mZ4oQ.png)
+![Micro Engineer](https://i.imgur.com/Gz7PgWL.png)
 
 # Links
 * Spacedock: https://spacedock.info/mod/3282/Micro%20Engineer
@@ -9,7 +9,7 @@ Displays useful in-flight information about your vessel, your orbital and surfac
 * Contact: [KSP 2 Modding Society](https://discord.com/channels/1078696971088433153/1080340366995239004)
 
 # Description
-A (heavily) KER inspired little mod to give you some additional information on your missions.
+A (heavily) KER inspired mod to give you some additional information on your missions.
 
 You can enable and disable individual sections and pop them out into their own window or create your own window containing only the information you want to see.
 

--- a/Staging/BepInEx/plugins/micro_engineer/swinfo.json
+++ b/Staging/BepInEx/plugins/micro_engineer/swinfo.json
@@ -1,16 +1,17 @@
 {
+    "spec": "1.2",
     "mod_id": "micro_engineer",
     "author": "Micrologist, Falki",
     "name": "Micro Engineer",
     "description": "Get in-flight and VAB information about your current vessel",
     "source": "https://github.com/Micrologist/MicroEngineer",
-    "version": "1.0.3",
+    "version": "1.1.0",
 	"version_check": "https://raw.githubusercontent.com/Micrologist/MicroEngineer/main/Staging/BepInEx/plugins/micro_engineer/swinfo.json",
     "dependencies": [
 		{
 		  "id":  "SpaceWarp",
 		  "version": {
-			"min": "1.0.1",
+			"min": "1.1.0",
 			"max": "*"
 		  }
 		}


### PR DESCRIPTION
- Added window snapping (can be turned off in settings)
- Added renaming of individual entries by user
- Converted Manager, UI and MessageManager to singletons
- Add support for SpaceWarp 1.2.0 (mod_id discontinued in favor of BepInEx GUID); backward compatibility with SW 1.1.x retained
- Updated readme screenshot