### PR TITLE
Fix textfields input locking

### DIFF
--- a/MicroEngineerProject/MicroEngineer.csproj
+++ b/MicroEngineerProject/MicroEngineer.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="BepInEx.BaseLib" Version="5.4.21" Publicize="true" />
 		<PackageReference Include="SpaceWarp" Version="1.4.0" />
 		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.1.4" PrivateAssets="all" />
+		<PackageReference Include="UitkForKsp2" Version="2.1.0" />
 	</ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<Exec Command="echo Killing task KSP2_x64.exe&#xD;&#xA;taskkill /f /fi &quot;pid gt 0&quot; /im KSP2_x64.exe&#xD;&#xA;&#xD;&#xA;echo Copying output .dll&#xD;&#xA;xcopy /y &quot;$(TargetDir)$(ProjectName).dll&quot; &quot;$(KSP2DIR)\BepInEx\plugins\micro_engineer\&quot;&#xD;&#xA;&#xD;&#xA;echo Copying output .pdb&#xD;&#xA;xcopy /y &quot;$(TargetDir)$(ProjectName).pdb&quot; &quot;$(KSP2DIR)\BepInEx\plugins\micro_engineer\&quot;&#xD;&#xA;&#xD;&#xA;echo Starting KSP2_x64.exe&#xD;&#xA;powershell &quot;start-process &quot;&quot;$(KSP2DIR)\KSP2_x64.exe&quot;&quot;&quot;" />

--- a/MicroEngineerProject/MicroEngineer.sln
+++ b/MicroEngineerProject/MicroEngineer.sln
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CD77478-E170-4D5C-91CA-0ABB24A30E5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/MicroEngineerProject/MicroEngineer/Entries/ManeuverEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/ManeuverEntries.cs
@@ -126,7 +126,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -146,7 +145,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -222,7 +220,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -244,7 +241,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -314,7 +310,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -595,8 +590,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
             Formatting = null;
         }
 
@@ -642,8 +635,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 3;
             Formatting = null;
         }
 
@@ -665,7 +656,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = false;
-            BaseUnit = null;
             Formatting = null;
         }
 
@@ -687,7 +677,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Maneuver;
             IsDefault = false;
-            BaseUnit = null;
             Formatting = null;
         }
 

--- a/MicroEngineerProject/MicroEngineer/Entries/MiscEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/MiscEntries.cs
@@ -50,8 +50,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
             Formatting = null;
         }
 
@@ -70,8 +68,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
             Formatting = null;
         }
 
@@ -90,9 +86,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()
@@ -110,9 +104,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()
@@ -210,9 +202,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()
@@ -230,9 +220,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Misc;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()

--- a/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
@@ -18,9 +18,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.OAB;
             IsDefault = true;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 1;
-            Formatting = "N";
+            Formatting = null;
             UseDHMSFormatting = true;
         }
 

--- a/MicroEngineerProject/MicroEngineer/Entries/OrbitalEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/OrbitalEntries.cs
@@ -65,7 +65,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Orbital;
             IsDefault = true;
-            BaseUnit = null;
             Formatting = null;
         }
 
@@ -84,7 +83,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Orbital;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -145,7 +143,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Orbital;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -427,9 +424,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Orbital;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 2;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()
@@ -493,7 +488,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Orbital;
             IsDefault = false;
-            BaseUnit = "s";
             Formatting = null;
         }
 

--- a/MicroEngineerProject/MicroEngineer/Entries/TargetEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/TargetEntries.cs
@@ -265,7 +265,6 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Target;
             IsDefault = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -522,9 +521,7 @@ namespace MicroMod
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Target;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 3;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()
@@ -684,7 +681,6 @@ namespace MicroMod
             Category = MicroEntryCategory.Target;
             IsDefault = true;
             HideWhenNoData = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 
@@ -768,7 +764,6 @@ namespace MicroMod
             Category = MicroEntryCategory.Target;
             IsDefault = false;
             HideWhenNoData = true;
-            BaseUnit = "s";
             Formatting = null;
         }
 

--- a/MicroEngineerProject/MicroEngineer/Entries/VesselEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/VesselEntries.cs
@@ -133,9 +133,7 @@
             EntryType = EntryType.Time;
             Category = MicroEntryCategory.Vessel;
             IsDefault = false;
-            BaseUnit = "s";
-            NumberOfDecimalDigits = 0;
-            Formatting = "N";
+            Formatting = null;
         }
 
         public override void RefreshData()

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -10,7 +10,7 @@ using BepInEx.Configuration;
 
 namespace MicroMod
 {
-    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.5.0")]
+    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.5.1")]
     [BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
     public class MicroEngineerMod : BaseSpaceWarpPlugin
 	{

--- a/MicroEngineerProject/MicroEngineer/UI/Controllers/EditWindowsController.cs
+++ b/MicroEngineerProject/MicroEngineer/UI/Controllers/EditWindowsController.cs
@@ -1,6 +1,7 @@
 ﻿using MicroMod;
 using UnityEngine;
 using UnityEngine.UIElements;
+using UitkForKsp2.API;
 
 namespace MicroEngineer.UI
 {
@@ -184,7 +185,7 @@ namespace MicroEngineer.UI
                 CheckIfDecimalButtonsShouldBeEnabled(e, incDecimal, decDecimal);
                 textField.RegisterCallback<MouseDownEvent>(evt => OnInstalledEntryClicked(evt, control));
                 textField.RegisterValueChangedCallback(evt => RenameEntry(evt, control));
-                Utility.DisableGameInputOnFocus(control);
+                textField.DisableGameInputOnFocus();
                 _installedControls.Add(control);
                 InstalledScrollView.Add(control);
             }
@@ -197,7 +198,7 @@ namespace MicroEngineer.UI
                 if (control != _selectedInstalledEntry)
                     SelectInstalled(control);
                 else if (Time.time - _timeOfLastClick < 0.5f)
-                    RemoveEntryFromInstalledWindow(); // double click on control
+                    RemoveEntryFromInstalledWindow(); // double click on control - doesn't work with UitkForKsp2 v2.1.1
                 else
                     UnselectInstalled(control); // longer than 500 ms since the last click, so we'll unselect the control
             }

--- a/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/Utility.cs
@@ -207,10 +207,12 @@ namespace MicroMod
             element.UnregisterCallback<GeometryChangedEvent>((evt) => CenterWindow(evt, element));
         }
 
+        /*
         public static void DisableGameInputOnFocus(this VisualElement element)
         {
             element.RegisterCallback<FocusInEvent>(_ => GameManager.Instance?.Game?.Input.Disable());
             element.RegisterCallback<FocusOutEvent>(_ => GameManager.Instance?.Game?.Input.Enable());
         }
+        */
     }    
 }

--- a/Staging/BepInEx/plugins/micro_engineer/swinfo.json
+++ b/Staging/BepInEx/plugins/micro_engineer/swinfo.json
@@ -5,7 +5,7 @@
     "name": "Micro Engineer",
     "description": "Get in-flight and VAB information about your current vessel",
     "source": "https://github.com/Micrologist/MicroEngineer",
-    "version": "1.5.0",
+    "version": "1.5.1",
 	"version_check": "https://raw.githubusercontent.com/Micrologist/MicroEngineer/main/Staging/BepInEx/plugins/micro_engineer/swinfo.json",
     "dependencies": [
 		{
@@ -18,7 +18,7 @@
 		{
 			"id":  "UitkForKsp2",
 			"version": {
-			"min": "2.1.0",
+			"min": "2.1.1",
 			"max": "*"
 			}
 		}


### PR DESCRIPTION
- Fixed textfields locking game input when they shouldn't have. It's now possible to rename windows and/or entries without locking the game

NOTE: in order for this fix to work correctly, "UITK for KSP 2" needs to be updated to v2.1.1 or later