### PR TITLE
v1.7.0 Fixes and Lat/Lon in decimal format

### DIFF
--- a/MicroEngineerProject/MicroEngineer/Entries/SurfaceEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/SurfaceEntries.cs
@@ -281,6 +281,25 @@ namespace MicroMod
             BaseUnit = Utility.ActiveVessel.Latitude < 0 ? "S" : "N";
         }
     }
+    
+    public class LatitudeDecimal : SurfaceEntry
+    {
+        public LatitudeDecimal()
+        {
+            Name = "Latitude (dec)";
+            Description = "Shows the vessel's latitude position around the celestial body. Latitude is the angle from the equator towards the poles. Decimal format.";
+            Category = MicroEntryCategory.Surface;
+            IsDefault = false;
+            BaseUnit = null;
+            NumberOfDecimalDigits = 3;
+            Formatting = "N";
+        }
+
+        public override void RefreshData()
+        {
+            EntryValue = Utility.ActiveVessel.Latitude;
+        }
+    }
 
     public class Longitude : SurfaceEntry
     {
@@ -298,6 +317,25 @@ namespace MicroMod
         {
             EntryValue = Utility.ActiveVessel.Longitude;
             BaseUnit = Utility.ActiveVessel.Longitude < 0 ? "W" : "E";
+        }
+    }
+    
+    public class LongitudeDecimal : SurfaceEntry
+    {
+        public LongitudeDecimal()
+        {
+            Name = "Longitude (dec)";
+            Description = "Shows the vessel's longitude position around the celestial body. Longitude is the angle from the body's prime meridian to the current meridian. Decimal format.";
+            Category = MicroEntryCategory.Surface;
+            IsDefault = false;
+            BaseUnit = null;
+            NumberOfDecimalDigits = 3;
+            Formatting = "N";
+        }
+
+        public override void RefreshData()
+        {
+            EntryValue = Utility.ActiveVessel.Longitude;
         }
     }
 

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -108,7 +108,17 @@ namespace MicroMod
         {
             while (true)
             {
-                Manager.Instance.DoFlightUpdate(); 
+                try
+                {
+                    Manager.Instance.DoFlightUpdate();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Unhandled exception in the DoFlightUpdate loop.\n" +
+                                    $"Exception: {ex.Message}\n" +
+                                    $"Stack Trace: {ex.StackTrace}");
+                }
+                 
                 yield return new WaitForSeconds((float)MainUpdateLoopUpdateFrequency.Value / 1000);
             }
         }

--- a/MicroEngineerProject/MicroEngineer/Utilities/TransferInfo.cs
+++ b/MicroEngineerProject/MicroEngineer/Utilities/TransferInfo.cs
@@ -1,4 +1,5 @@
-﻿using KSP.Sim.impl;
+﻿using BepInEx.Logging;
+using KSP.Sim.impl;
 using KSP.Sim;
 using UnityEngine;
 
@@ -28,8 +29,19 @@ namespace MicroMod
                 return false;
             }
 
-            (CelestialBodyComponent referenceBody, Vector3 localPosition, IKeplerOrbit currentOrbit) from = (Utility.ActiveVessel.Orbit.referenceBody, Utility.ActiveVessel.Orbit.Position.localPosition, Utility.ActiveVessel.Orbit);
-            (CelestialBodyComponent referenceBody, Vector3 localPosition, IKeplerOrbit currentOrbit) to = (Utility.ActiveVessel.TargetObject.Orbit.referenceBody, Utility.ActiveVessel.TargetObject.Orbit.Position.localPosition, Utility.ActiveVessel.TargetObject.Orbit);
+            (CelestialBodyComponent referenceBody, Vector3 localPosition, IKeplerOrbit currentOrbit) from;
+            (CelestialBodyComponent referenceBody, Vector3 localPosition, IKeplerOrbit currentOrbit) to;
+            
+            try
+            {
+                from = (Utility.ActiveVessel.Orbit.referenceBody, Utility.ActiveVessel.Orbit.Position.localPosition, Utility.ActiveVessel.Orbit);
+                to = (Utility.ActiveVessel.TargetObject.Orbit.referenceBody, Utility.ActiveVessel.TargetObject.Orbit.Position.localPosition, Utility.ActiveVessel.TargetObject.Orbit);
+            }
+            catch (Exception _)
+            {
+                // due to a game bug, sometimes TargetObject doesn't have an orbit
+                return false;
+            }
 
             // We search for the common celestial body that both ActiveVessel and TargetObject are orbiting and then calculate the phase angle
             bool commonReferenceBodyFound = false;


### PR DESCRIPTION
- Fixed a bug that sometimes caused Micro Engineer to stop refreshing values after docking vessels
- Added 2 new entries:
  - Surface category:
    - Latitude (dec): shows latitude, but in decimal format
    - Longitude (dec): shows longitude, but in decimal format

Note: new entries do not show in the active window by default. If you want them, add them via the Edit window (gear icon)