### PR TITLE
v1.7.1 OAB fixes

### DIFF
--- a/MicroEngineerProject/MicroEngineer.csproj
+++ b/MicroEngineerProject/MicroEngineer.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
 		<PackageReference Include="HarmonyX" Version="2.10.1" />
 		<PackageReference Include="UitkForKsp2" Version="2.4.0" />
-		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.2.0" PrivateAssets="all" />
+		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.2.0" PrivateAssets="all" Publicize="true"/>
 		<PackageReference Include="SpaceWarp" Version="1.7.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2020.3.33.1" />
 		<PackageReference Include="UnityEngine.UITK" Version="2020.3.33.1" Publicize="true" />

--- a/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
@@ -191,6 +191,10 @@ namespace MicroMod
                 var stage = new DeltaVStageInfo_OAB()
                 {
                     Index = i,
+                    // if stock stage info celestial body is set to any other body than the home body (Kerbin), set it here.
+                    // TWR and DeltaV recalculations won't be done for other bodies since the game already does this
+                    SituationCelestialBody = retrieved.DeltaVSituation.CelestialBody == MicroCelestialBodies.HomeWorld
+                        ? string.Empty : retrieved.DeltaVSituation.CelestialBody,
                     DeltaVActual = retrieved.DeltaVActual,
                     DeltaVASL = retrieved.DeltaVatASL,
                     DeltaVVac = retrieved.DeltaVinVac,
@@ -231,9 +235,14 @@ namespace MicroMod
                 }
 
                 // Apply TWR factor to the value and recalculate sea level TWR and DeltaV
-                stage.Recalculate_TWR();
-                stage.Recalculate_SLT();
-                stage.Recalculate_DeltaVSeaLevel();
+                // Do this only if stock body readout is set to home body (Kerbin) since the game already does this for other bodies 
+                if (string.IsNullOrEmpty(stage.SituationCelestialBody))
+                {
+                    stage.Recalculate_TWR();
+                    stage.Recalculate_SLT();
+                    stage.Recalculate_DeltaVSeaLevel();    
+                }
+                
                 
                 // KSP2 has a strange way of displaying stage numbers, so we need a little hack
                 stage.Recalculate_StageNumber(Utility.VesselDeltaVComponentOAB.StageInfo.Count);
@@ -270,6 +279,7 @@ namespace MicroMod
         /// When stages are refreshed, DeltaVStageInfo_OAB grabs the CelestialBodyForStage at the same Index.
         /// </summary>
         public int Index;
+        public string SituationCelestialBody;
         public double DeltaVActual;
         public double DeltaVASL;
         public double DeltaVVac;

--- a/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
+++ b/MicroEngineerProject/MicroEngineer/Entries/OabStageInfoEntries.cs
@@ -224,7 +224,8 @@ namespace MicroMod
                 if (i < CelestialBodyForStage.Count)
                 {
                     // CelestialBody already created for this stage. Attaching it to the stage.
-                    stage.CelestialBody = CelestialBodyForStage[i];
+                    stage.CelestialBody = CelestialBodyForStage[CelestialBodyForStage.Count - 1 - i];
+                    
                 }
                 else
                 {
@@ -242,7 +243,6 @@ namespace MicroMod
                     stage.Recalculate_SLT();
                     stage.Recalculate_DeltaVSeaLevel();    
                 }
-                
                 
                 // KSP2 has a strange way of displaying stage numbers, so we need a little hack
                 stage.Recalculate_StageNumber(Utility.VesselDeltaVComponentOAB.StageInfo.Count);
@@ -264,7 +264,7 @@ namespace MicroMod
         public void UpdateCelestialBodyAtIndex(int index, string selectedBodyName)
         {
             var body = MicroCelestialBodies.Instance.GetBodyByName(selectedBodyName);
-            CelestialBodyForStage[index] = body;
+            CelestialBodyForStage[CelestialBodyForStage.Count - 1 - index] = body;
             RefreshData();
         }
     }

--- a/MicroEngineerProject/MicroEngineer/Managers/MicroCelestialBodies.cs
+++ b/MicroEngineerProject/MicroEngineer/Managers/MicroCelestialBodies.cs
@@ -11,6 +11,8 @@ namespace MicroMod
 
         public List<CelestialBody> Bodies = new();
 
+        public static string HomeWorld { get; set; }
+
         public static MicroCelestialBodies Instance
         {
             get
@@ -58,6 +60,12 @@ namespace MicroMod
                     IsHomeWorld = body.isHomeWorld,
                     CelestialBodyComponent = body,
                 });
+
+                // set the HomeWorld body that will be read by the StageInfoOAB update patch
+                if (body.isHomeWorld)
+                {
+                    HomeWorld = body.Name;
+                }
             }
 
             // Reorder and format all celestial bodies so they form a tree-like structure

--- a/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
+++ b/MicroEngineerProject/MicroEngineer/MicroEngineerMod.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using BepInEx;
 using UnityEngine;
 using SpaceWarp;
@@ -11,7 +10,7 @@ using BepInEx.Configuration;
 
 namespace MicroMod
 {
-    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.7.0")]
+    [BepInPlugin("com.micrologist.microengineer", "MicroEngineer", "1.7.1")]
     [BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
     public class MicroEngineerMod : BaseSpaceWarpPlugin
 	{

--- a/MicroEngineerProject/MicroEngineer/UI/Controls/StageInfoOABEntryControl.cs
+++ b/MicroEngineerProject/MicroEngineer/UI/Controls/StageInfoOABEntryControl.cs
@@ -134,7 +134,9 @@ namespace MicroEngineer.UI
 
             Body = bodies;
             BodyDropdown.SetValueWithoutNotify(selectedBody);
-            BodyDropdown.SetEnabled(true);
+
+            // enabled the dropdown control only if there is more than one option
+            BodyDropdown.SetEnabled(bodies.Count > 1);
         }
 
         public StageInfoOABEntryControl(int stageNumber, float twr, float slt, double aslDeltaV, double vacDeltaV, int burnDays, int burnHours, int burnMinutes, int burnSeconds, List<string> bodies, string selectedBody) : this()


### PR DESCRIPTION
- Fix OAB TWR and DeltaV calculations if celestial body is changed in the stock dv tool - reported by @Deadly_Laser
  - Explanation of the solution: if another body is selected in the game's dv tool, then Micro Engineer's body dropdown will be locked to that selected body. If body in the game's dv tool is switched back to Kerbin, then Micro Engineer's body dropdown will be unlocked too.
- OAB stages now keep their selected body - requested by @adaniel87
  - Note: this update can take a while, up to a few seconds - no need to report this.